### PR TITLE
Feature/exercises/8.1.2

### DIFF
--- a/app/assets/stylesheets/custom.scss
+++ b/app/assets/stylesheets/custom.scss
@@ -161,3 +161,18 @@ input, textarea {
 input {
   height: auto !important;
 }
+
+#error_explanation {
+  color: red;
+  ul {
+    color: red;
+    margin: 0 0 30px 0;
+  }
+}
+
+.field_with_errors {
+  @extend .has-error;
+  .form-control {
+    color: $state-danger-text;
+  }
+}

--- a/app/assets/stylesheets/custom.scss
+++ b/app/assets/stylesheets/custom.scss
@@ -96,3 +96,12 @@ footer {
     }
   }
 }
+
+/* miscellaneous */
+
+.debug_dump {
+  clear: both;
+  float: left;
+  width: 100%;
+  margin-top: 45px;
+}

--- a/app/assets/stylesheets/custom.scss
+++ b/app/assets/stylesheets/custom.scss
@@ -105,3 +105,40 @@ footer {
   width: 100%;
   margin-top: 45px;
 }
+
+/* sidebar */
+
+aside {
+  section.user_info {
+    margin-top: 20px;
+  }
+  section {
+    padding: 10px 0;
+    margin-top: 20px;
+    &:first-child {
+      border: 0;
+      padding-top: 0;
+    }
+    span {
+      display: block;
+      margin-bottom: 3px;
+      line-height: 1;
+    }
+    h1 {
+      font-size: 1.4em;
+      text-align: left;
+      letter-spacing: -1px;
+      margin-bottom: 3px;
+      margin-top: 0px;
+    }
+  }
+}
+
+.gravatar {
+  float: left;
+  margin-right: 10px;
+}
+
+.gravatar_edit {
+  margin-top: 15px;
+}

--- a/app/assets/stylesheets/custom.scss
+++ b/app/assets/stylesheets/custom.scss
@@ -5,6 +5,12 @@
 
 $gray-medium-light: #eaeaea;
 
+@mixin box_sizing {
+  -moz-box-sizing:    border-box;
+  -webkit-box-sizing: border-box;
+  box-sizing:         border-box;
+}
+
 /* universal */
 
 body {
@@ -141,4 +147,17 @@ aside {
 
 .gravatar_edit {
   margin-top: 15px;
+}
+
+/* forms */
+
+input, textarea {
+  border: 1px solid #bbb;
+  width: 100%;
+  margin-bottom: 15px;
+  @include box_sizing;
+}
+
+input {
+  height: auto !important;
 }

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -1,0 +1,4 @@
+class SessionsController < ApplicationController
+  def new
+  end
+end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,4 +1,9 @@
 class UsersController < ApplicationController
+  
+  def show
+    @user = User.find(params[:id])
+  end
+
   def new
   end
 end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -5,5 +5,6 @@ class UsersController < ApplicationController
   end
 
   def new
+    @user = User.new
   end
 end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,5 +1,5 @@
 class UsersController < ApplicationController
-  
+
   def show
     @user = User.find(params[:id])
   end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -8,7 +8,7 @@ class UsersController < ApplicationController
     @user = User.new
   end
 
-  def Create
+  def create
     @user = User.new(user_params)
     if @user.save
       # 保存の成功をここで扱う。

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -21,6 +21,6 @@ class UsersController < ApplicationController
 
     def user_params
       params.require(:user).permit(:name, :email, :password,
-                                  :password_confirmation)
+                                   :password_confirmation)
     end
 end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -11,7 +11,7 @@ class UsersController < ApplicationController
   def create
     @user = User.new(user_params)
     if @user.save
-      # 保存の成功をここで扱う。
+      redirect_to user_url(@user)
     else
       render 'new', status: :unprocessable_entity
     end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -11,6 +11,7 @@ class UsersController < ApplicationController
   def create
     @user = User.new(user_params)
     if @user.save
+      flash[:success] = "Welcome to the Sample App!"
       redirect_to user_url(@user)
     else
       render 'new', status: :unprocessable_entity

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -7,4 +7,20 @@ class UsersController < ApplicationController
   def new
     @user = User.new
   end
+
+  def Create
+    @user = User.new(user_params)
+    if @user.save
+      # 保存の成功をここで扱う。
+    else
+      render 'new', status: :unprocessable_entity
+    end
+  end
+
+  private
+
+    def user_params
+      params.require(:user).permit(:name, :email, :password,
+                                  :password_confirmation)
+    end
 end

--- a/app/helpers/sessions_helper.rb
+++ b/app/helpers/sessions_helper.rb
@@ -1,0 +1,2 @@
+module SessionsHelper
+end

--- a/app/helpers/users_helper.rb
+++ b/app/helpers/users_helper.rb
@@ -1,2 +1,10 @@
 module UsersHelper
-end
+
+    # 引数で与えられたユーザーのGravatar画像を返す
+    def gravatar_for(user, size: 80)
+      gravatar_id  = Digest::MD5::hexdigest(user.email.downcase)
+      gravatar_url = "https://secure.gravatar.com/avatar/#{gravatar_id}?s=#{size}"
+      image_tag(gravatar_url, alt: user.name, class: "gravatar")
+    end
+  end
+  

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -4,6 +4,9 @@
   <body>
     <%= render 'layouts/header' %>
     <div class="container">
+      <% flash.each do |message_type, message| %>
+        <div class="alert alert-<%= message_type %>"><%= message %></div>
+      <% end %>
       <%= yield %>
       <%= render 'layouts/footer' %>
       <%= debug(params) if Rails.env.development? %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -6,6 +6,7 @@
     <div class="container">
       <%= yield %>
       <%= render 'layouts/footer' %>
+      <%= debug(params) if Rails.env.development? %>
     </div>
   </body>
 </html>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -5,7 +5,7 @@
     <%= render 'layouts/header' %>
     <div class="container">
       <% flash.each do |message_type, message| %>
-        <div class="alert alert-<%= message_type %>"><%= message %></div>
+        <%= content_tag(:div, message, class: "alert alert-#{message_type}") %>
       <% end %>
       <%= yield %>
       <%= render 'layouts/footer' %>

--- a/app/views/sessions/new.html.erb
+++ b/app/views/sessions/new.html.erb
@@ -1,2 +1,19 @@
-<h1>Sessions#new</h1>
-<p>Find me in app/views/sessions/new.html.erb</p>
+<% provide(:title, "Log in") %>
+<h1>Log in</h1>
+
+<div class="row">
+  <div class="col-md-6 col-md-offset-3">
+    <%= form_with(url: login_path, scope: :session) do |f| %>
+
+      <%= f.label :email %>
+      <%= f.email_field :email, class: 'form-control' %>
+
+      <%= f.label :password %>
+      <%= f.password_field :password, class: 'form-control' %>
+
+      <%= f.submit "Log in", class: "btn btn-primary" %>
+    <% end %>
+
+    <p>New user? <%= link_to "Sign up now!", signup_path %></p>
+  </div>
+</div>

--- a/app/views/sessions/new.html.erb
+++ b/app/views/sessions/new.html.erb
@@ -1,0 +1,2 @@
+<h1>Sessions#new</h1>
+<p>Find me in app/views/sessions/new.html.erb</p>

--- a/app/views/shared/_error_messages.html.erb
+++ b/app/views/shared/_error_messages.html.erb
@@ -1,0 +1,12 @@
+<% if @user.errors.any? %>
+  <div id="error_explanation">
+    <div class="alert alert-danger">
+      The form contains <%= pluralize(@user.errors.count, "error") %>.
+    </div>
+    <ul>
+    <% @user.errors.full_messages.each do |msg| %>
+      <li><%= msg %></li>
+    <% end %>
+    </ul>
+  </div>
+<% end %>

--- a/app/views/users/new.html.erb
+++ b/app/views/users/new.html.erb
@@ -4,17 +4,19 @@
 <div class="row">
   <div class="col-md-6 col-md-offset-3">
     <%= form_with(model: @user) do |f| %>
+      <%= render 'shared/error_messages' %>
+
       <%= f.label :name %>
-      <%= f.text_field :name %>
+      <%= f.text_field :name, class: 'form-control' %>
 
       <%= f.label :email %>
-      <%= f.email_field :email %>
+      <%= f.email_field :email, class: 'form-control' %>
 
       <%= f.label :password %>
-      <%= f.password_field :password %>
+      <%= f.password_field :password, class: 'form-control' %>
 
       <%= f.label :password_confirmation, "Confirmation" %>
-      <%= f.password_field :password_confirmation %>
+      <%= f.password_field :password_confirmation, class: 'form-control' %>
 
       <%= f.submit "Create my account", class: "btn btn-primary" %>
     <% end %>

--- a/app/views/users/new.html.erb
+++ b/app/views/users/new.html.erb
@@ -1,3 +1,22 @@
 <% provide(:title, 'Sign up') %>
 <h1>Sign up</h1>
-<p>This will be a signup page for new users.</p>
+
+<div class="row">
+  <div class="col-md-6 col-md-offset-3">
+    <%= form_with(model: @user) do |foobar| %>
+      <%= foobar.label :name %>
+      <%= foobar.text_field :name %>
+
+      <%= foobar.label :email %>
+      <%= foobar.email_field :email %>
+
+      <%= foobar.label :password %>
+      <%= foobar.password_field :password %>
+
+      <%= foobar.label :password_confirmation, "Confirmation" %>
+      <%= foobar.password_field :password_confirmation %>
+
+      <%= foobar.submit "Create my account", class: "btn btn-primary" %>
+    <% end %>
+  </div>
+</div>

--- a/app/views/users/new.html.erb
+++ b/app/views/users/new.html.erb
@@ -3,20 +3,20 @@
 
 <div class="row">
   <div class="col-md-6 col-md-offset-3">
-    <%= form_with(model: @user) do |foobar| %>
-      <%= foobar.label :name %>
-      <%= foobar.text_field :name %>
+    <%= form_with(model: @user) do |f| %>
+      <%= f.label :name %>
+      <%= f.text_field :name %>
 
-      <%= foobar.label :email %>
-      <%= foobar.email_field :email %>
+      <%= f.label :email %>
+      <%= f.email_field :email %>
 
-      <%= foobar.label :password %>
-      <%= foobar.password_field :password %>
+      <%= f.label :password %>
+      <%= f.password_field :password %>
 
-      <%= foobar.label :password_confirmation, "Confirmation" %>
-      <%= foobar.password_field :password_confirmation %>
+      <%= f.label :password_confirmation, "Confirmation" %>
+      <%= f.password_field :password_confirmation %>
 
-      <%= foobar.submit "Create my account", class: "btn btn-primary" %>
+      <%= f.submit "Create my account", class: "btn btn-primary" %>
     <% end %>
   </div>
 </div>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -1,0 +1,3 @@
+<%= @user.name %>, <%= @user.email %>,
+<%= @user.created_at %>, <%= @user.updated_at %>,
+現在の時刻：<%= Time.now %>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -1,3 +1,11 @@
-<%= @user.name %>, <%= @user.email %>,
-<%= @user.created_at %>, <%= @user.updated_at %>,
-現在の時刻：<%= Time.now %>
+<% provide(:title, @user.name) %>
+<div class="row">
+  <aside class="col-md-4">
+    <section class="user_info">
+      <h1>
+        <%= gravatar_for @user, size: 100 %>
+        <%= @user.name %>
+      </h1>
+    </section>
+  </aside>
+</div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -4,4 +4,5 @@ Rails.application.routes.draw do
   get  "/about",   to: "static_pages#about"
   get  "/contact", to: "static_pages#contact"
   get  "/signup",  to: 'users#new'
+  resources :users
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -4,5 +4,8 @@ Rails.application.routes.draw do
   get  "/about",   to: "static_pages#about"
   get  "/contact", to: "static_pages#contact"
   get  "/signup",  to: 'users#new'
+  get    "/login",   to: "sessions#new"
+  post   "/login",   to: "sessions#create"
+  delete "/logout",  to: "sessions#destroy"
   resources :users
 end

--- a/test/controllers/sessions_controller_test.rb
+++ b/test/controllers/sessions_controller_test.rb
@@ -1,0 +1,8 @@
+require "test_helper"
+
+class SessionsControllerTest < ActionDispatch::IntegrationTest
+  test "should get new" do
+    get login_path
+    assert_response :success
+  end
+end

--- a/test/integration/users_signup_test.rb
+++ b/test/integration/users_signup_test.rb
@@ -31,5 +31,6 @@ class UsersSignupTest < ActionDispatch::IntegrationTest
     end
     follow_redirect!
     assert_template 'users/show'
+    assert_not flash.empty? 
   end
 end

--- a/test/integration/users_signup_test.rb
+++ b/test/integration/users_signup_test.rb
@@ -1,0 +1,25 @@
+require "test_helper"
+
+class UsersSignupTest < ActionDispatch::IntegrationTest
+
+  test "invalid signup information" do
+    get signup_path
+    assert_no_difference 'User.count' do
+      post users_path, params: { user: { name:  "",
+                                         email: "user@invalid",
+                                         password:              "foo",
+                                         password_confirmation: "bar" } }
+    end
+    assert_response :unprocessable_entity
+    assert_template 'users/new'
+
+    assert_select 'div#error_explanation'
+    assert_select 'div.alert.alert-danger', text: /The form contains \d+ errors/
+
+    assert_select 'ul li', text: "Name can't be blank"
+    assert_select 'ul li', text: "Email is invalid"
+    assert_select 'ul li', text: "Password is too short (minimum is 8 characters)"
+    assert_select 'ul li', text: "Password confirmation doesn't match Password"
+        
+  end
+end

--- a/test/integration/users_signup_test.rb
+++ b/test/integration/users_signup_test.rb
@@ -19,7 +19,17 @@ class UsersSignupTest < ActionDispatch::IntegrationTest
     assert_select 'ul li', text: "Name can't be blank"
     assert_select 'ul li', text: "Email is invalid"
     assert_select 'ul li', text: "Password is too short (minimum is 8 characters)"
-    assert_select 'ul li', text: "Password confirmation doesn't match Password"
-        
+    assert_select 'ul li', text: "Password confirmation doesn't match Password" 
+  end
+
+  test "valid signup information" do
+    assert_difference 'User.count', 1 do
+      post users_path, params: { user: { name:  "Example User",
+                                         email: "user@example.com",
+                                         password:              "password",
+                                         password_confirmation: "password" } }
+    end
+    follow_redirect!
+    assert_template 'users/show'
   end
 end


### PR DESCRIPTION
[Railsチュートリアル：演習8.1.2](https://railstutorial.jp/chapters/basic_login?version=7.0#sec-exercises_login_form)

## 演習
[リスト 8.4](https://railstutorial.jp/chapters/basic_login?version=7.0#code-login_form)で定義したフォームで送信すると、Sessionsコントローラのcreateアクションに到達します。Railsはこれをどうやって実現しているでしょうか? 考えてみてください。（ヒント:[表 8.1](https://railstutorial.jp/chapters/basic_login?version=7.0#table-RESTful_sessions)と[リスト 8.5](https://railstutorial.jp/chapters/basic_login?version=7.0#code-login_form_html)の1行目に注目してください。）

### 回答
`config/routes.rb`で以下のように定義して実現している。
```ruby
post   "/login",   to: "sessions#create"
```
これにより/loginでpostメソッドを使用した場合、Sessionsコントローラのcreateアクションに到達する。
